### PR TITLE
Add mock data mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+server/node_modules/
+server/package-lock.json
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,4 +15,15 @@ This project contains a simple Node.js/Express server and a web client for displ
    ```
    or start normally with `npm start`.
 
+### Offline sample data
+
+If access to external APIs is restricted, you can run the server with built-in
+sample responses. Set the `USE_MOCK` environment variable:
+
+```bash
+USE_MOCK=true npm start
+```
+
+This allows the dashboard to function without internet access.
+
 The client is served from `/client` and will be accessible at `http://localhost:3000` by default.

--- a/server/routes/ah.js
+++ b/server/routes/ah.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const router = express.Router();
-const wowauctions = require('../services/wowauctions');
-const turtleDB    = require('../services/turtleDB');
+const useMock = process.env.USE_MOCK === 'true';
+const wowauctions = useMock
+  ? require('../services/mockData')
+  : require('../services/wowauctions');
+const turtleDB = useMock
+  ? require('../services/mockData')
+  : require('../services/turtleDB');
 
 router.get('/', (req, res) => {
   console.log('Health check ping /api/ah/');

--- a/server/services/mockData.js
+++ b/server/services/mockData.js
@@ -1,0 +1,29 @@
+const mockItems = {
+  111: {
+    name: 'Sample Item 111',
+    quality: 1,
+    icon: null,
+    craftCost: null
+  },
+  222: {
+    name: 'Sample Item 222',
+    quality: 2,
+    icon: null,
+    craftCost: null
+  }
+};
+
+const mockAuctions = {
+  111: { avgPrice: 10, volume: 5, globalMin: 8, globalMax: 12 },
+  222: { avgPrice: 50, volume: 2, globalMin: 48, globalMax: 55 }
+};
+
+function fetchItem(realm, id) {
+  return Promise.resolve(mockAuctions[id] || { avgPrice: 0, volume: 0, globalMin: null, globalMax: null });
+}
+
+function fetchItemInfo(id) {
+  return Promise.resolve(mockItems[id] || { name: `Item ${id}`, quality: 0, icon: null, craftCost: null });
+}
+
+module.exports = { fetchItem, fetchItemInfo };


### PR DESCRIPTION
## Summary
- add `.gitignore`
- add optional mock data service
- allow switching to mock data with `USE_MOCK` environment variable
- document offline mode in README

## Testing
- `npm install`
- `USE_MOCK=true node server.js` and `curl http://localhost:3000/api/ah/item/111`

------
https://chatgpt.com/codex/tasks/task_e_68690b8a23f08325b8a64cdd33b9139c